### PR TITLE
fix/CON-252-json_ponto_flutuante

### DIFF
--- a/includes/class-wc-rakuten-pay-credit-card-gateway.php
+++ b/includes/class-wc-rakuten-pay-credit-card-gateway.php
@@ -558,7 +558,7 @@ class WC_Rakuten_Pay_Credit_Card_Gateway extends WC_Payment_Gateway_CC {
 
     return $fields;
   }
-
+//TODO verificar método
 //  public function checkout_shipping_document_fields( $fields ) {
 //    $shipping_fields = $fields['shipping'];
 //


### PR DESCRIPTION
# Propósito

**Jira Card:** [[Pay] Tratar json_encode para presenvar o ponto flutuante.](https://rakutenbrazil.atlassian.net/browse/CON-252)

Este PR Ajusta a condição sobre a constante JSON_PRESERVE_ZER_FRACTION a partir do php 5.6.6.
 
# Tarefas Realizadas

- [X] Criado método getJson que trata a condição para utilizar o json_encode com JSON_PRESERVE_ZERO_FRACTION.
- [X] Criado método preserveZeroFractionInstallments utilizado para tranformando o arry em string e atuar como o substituto da constante utilizada.
- [X] Criado método installmentsToFloat que trata a string gerada como float em conjunto com o método preserveZeroFraction